### PR TITLE
rebpf: redefine the flag enums as proper bitflags

### DIFF
--- a/rebpf/Cargo.toml
+++ b/rebpf/Cargo.toml
@@ -15,5 +15,6 @@ keywords = ["bpf", "ebpf", "rebpf", "xdp"]
 [dependencies]
 libc = "0.2.66"
 libbpf-sys = "0.0.7-1"
+bitflags = "1.2"
 rebpf-macro = { path = "../rebpf-macro", version = "0.1.0" }
 function_name = "0.2.0"


### PR DESCRIPTION
The proper way to represent flags in Rust isn't to use enums, as by
definition the members of the enum are mutually exclusive, and as such a
"flags" parameter taking an enum can only have one flag set. However,
from a type standpoint, such parameter should be able to represent an
arbitrary set of the flag constants.

As of this writing, the idiomatic way to define such types in Rust is by
using the bitflags crate, that will simply create a struct with the
standard bitfield operation along with a readonly access to the
underlying data structure (and a private access if you want to refine
the behaviour of your bitfield).

As a bonus, since the flag constants are now actual constants and not
subtypes, we don't get yelled at by the compiler for not respecting the
Rust naming conventions \o/.

This patch transitions the BpfMapUpdateElem enum (that are semantically
mutually exclusive, true, but future API additions might bring other
flags that might not conflict with those without breaking ABI) as well
as the XdpFlags enum.

Closes #7 