### PR TITLE
rebpf: remove superfluous transmute

### DIFF
--- a/rebpf/src/lib.rs
+++ b/rebpf/src/lib.rs
@@ -484,9 +484,9 @@ pub fn bpf_set_link_xdp_fd(
     let err = unsafe {
         if bpf_fd.is_some() {
             let bpf_fd = bpf_fd.unwrap();
-            libbpf::bpf_set_link_xdp_fd(interface.ifindex as i32, bpf_fd.fd, mem::transmute(xdp_flags))
+            libbpf::bpf_set_link_xdp_fd(interface.ifindex as i32, bpf_fd.fd, xdp_flags.bits())
         } else {
-            libbpf::bpf_set_link_xdp_fd(interface.ifindex as i32, -1, mem::transmute(xdp_flags))
+            libbpf::bpf_set_link_xdp_fd(interface.ifindex as i32, -1, xdp_flags.bits())
         }
     };
     if err < 0 {


### PR DESCRIPTION
Using transmute on bitflags is a bit of an overkill, when one can simply
use the bits() method to access the underlying data. Granted, this
method isn't particularly well documented, but it is listed there :

https://docs.rs/bitflags/1.2.1/bitflags/#methods-1

As a bonus, we don't rely on the hope that the generated bitflags struct
is a transparent wrapper around the u32 bitfield. Of course, it *is*
transparent, but still :-).