### PR TITLE
Userspace maps (+ update operation)

### DIFF
--- a/examples/basic03_map_counter/src/common_kern_user.rs
+++ b/examples/basic03_map_counter/src/common_kern_user.rs
@@ -5,9 +5,10 @@
 
 use std::sync::atomic::AtomicU64;
 
+#[derive(Default)]
 #[repr(C)]
 pub struct DataRec {
-    pub rx_packets: AtomicU64
+    pub rx_packets: AtomicU64,
 }
 
 pub const MAX_ENTRIES: u32 = 5;

--- a/examples/basic03_map_counter/src/kern.rs
+++ b/examples/basic03_map_counter/src/kern.rs
@@ -11,7 +11,7 @@ use rebpf::{
     VERSION,
     rebpf_macro::sec,
     libbpf::{XdpAction, XdpMd},
-    bpf::maps::{Array, Lookup},
+    bpf::maps::{Array, LookupMut},
 };
 use std::sync::atomic::Ordering::Relaxed;
 

--- a/examples/basic03_map_counter/src/user.rs
+++ b/examples/basic03_map_counter/src/user.rs
@@ -43,8 +43,7 @@ fn find_map_by_fd<T, U>(
     bpf_object: &libbpf::BpfObject,
     map_name: &str,
 ) -> Result<libbpf::BpfMapFd<T, U>, rebpf_error::Error> {
-    let bpf_map = libbpf::bpf_object__find_map_by_name(bpf_object, map_name)?
-        .ok_or(rebpf_error::Error::InvalidMapName)?;
+    let bpf_map = libbpf::bpf_object__find_map_by_name(bpf_object, map_name)?;
 
     libbpf::bpf_map__fd(&bpf_map)
 }

--- a/rebpf/src/bpf/maps.rs
+++ b/rebpf/src/bpf/maps.rs
@@ -102,8 +102,8 @@ map_def! {
     /// Example :
     ///
     /// ```
-    /// use rebpf::maps::{CpuMap, Redirect};
-    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf::bpf::maps::{CpuMap, Redirect};
+    /// use rebpf::libbpf::{XdpAction, XdpMd};
     /// use rebpf_macro::sec;
     ///
     /// // Allocate a map to be able to dispatch traffic to the first 8 CPUs of the system.
@@ -128,8 +128,8 @@ map_def! {
     /// Example :
     ///
     /// ```
-    /// use rebpf::maps::{XskMap, Redirect};
-    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf::bpf::maps::{XskMap, Redirect};
+    /// use rebpf::libbpf::{XdpAction, XdpMd};
     /// use rebpf_macro::sec;
     ///
     /// // Allocate a single-slot map to host our only socket.
@@ -154,8 +154,8 @@ map_def! {
     /// Example :
     ///
     /// ```
-    /// use rebpf::maps::{DevMap, Redirect};
-    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf::bpf::maps::{DevMap, Redirect};
+    /// use rebpf::libbpf::{XdpAction, XdpMd};
     /// use rebpf_macro::sec;
     ///
     /// // Allocate a single-slot map to host our port map.

--- a/rebpf/src/bpf/maps.rs
+++ b/rebpf/src/bpf/maps.rs
@@ -8,34 +8,59 @@ use crate::{
 /// communicate with userspace. As the capabilities of the maps vary greatly, most of their
 /// behaviour is exposed via specific traits.
 
-macro_rules! impl_map {
-    ($map_def:ident < $($g:ident),* >, $map_type:expr) => {
-        impl<$($g),*> $map_def<$($g),*> {
-            map_new!($map_def < $($g),* >, $map_type);
+macro_rules! map_new {
+    ($map_type:path: $type_const:expr) => {
+        pub const fn new(max_entries: u32) -> $map_type {
+            $map_type {
+                def: BpfMapDef::new($type_const, max_entries),
+            }
         }
-    }
+    };
 }
 
-macro_rules! map_new {
-    ($map_def:ident < $($g:ident),* >, $map_type:expr) => {
-        pub const fn new(max_entries: u32) -> $map_def<$($g),*> {
-            $map_def(BpfMapDef::new($map_type, max_entries))
+macro_rules! map_def {
+    ($(#[$outer:meta])*
+    struct $map_type:ident < $key:ty, $value:ty >: $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type<$key, $value> {
+            def: BpfMapDef<$key, $value>,
         }
-    }
+        impl<$key, $value> $map_type<$key, $value> { map_new! {$map_type<$key, $value>: $type_const} }
+        impl<$key, $value> Map for $map_type<$key, $value> { type Key = $key; type Value = $value; }
+    };
+    ($(#[$outer:meta])*
+    struct $map_type:ident < $value:ident >: $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type <$value> {
+            def: BpfMapDef<u32, $value>,
+        }
+        impl<$value> $map_type<$value> { map_new! {$map_type<$value>: $type_const} }
+        impl<$value> Map for $map_type<$value> { type Key = u32; type Value = $value; }
+    };
+    ($(#[$outer:meta])*
+    struct $map_type:ident : $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type {
+            def: BpfMapDef<u32, u32>,
+        }
+        impl $map_type { map_new! {$map_type: $type_const} }
+        impl Map for $map_type { type Key = u32; type Value = u32; }
+    };
 }
 
 /// This trait represents the ability for a map to specify an XDP redirection, whether to a network
 /// device, a CPU, or a socket.
-pub trait Redirect {
-    fn redirect_or(&self, target: u32, default_action: XdpAction) -> XdpAction;
-    fn redirect(&self, target: u32) -> XdpAction {
+pub trait Redirect: Map {
+    fn redirect_or(&self, target: Self::Key, default_action: XdpAction) -> XdpAction;
+    fn redirect(&self, target: Self::Key) -> XdpAction {
         self.redirect_or(target, XdpAction::ABORTED)
     }
 }
 
-pub trait LookupMut {
-    type Key;
-    type Value;
+pub trait LookupMut: Map {
     /// Lookup the map content associated with the given key.
     ///
     /// # Safety
@@ -50,145 +75,113 @@ pub trait LookupMut {
 }
 
 macro_rules! impl_map_redirect {
-    ($map_def:ident < $($g:ident),* >) => {
-        impl<$($g),*> Redirect for $map_def<$($g),*> {
+    ($map_def:ty) => {
+        impl Redirect for $map_def {
             fn redirect_or(&self, target: u32, default_action: XdpAction) -> XdpAction {
-                bpf_redirect_map(&self.0, &target, default_action)
+                bpf_redirect_map(&self.def, &target, default_action)
             }
         }
     };
 }
 
-/// macro to impl Lookup trait.
 macro_rules! impl_map_lookup_mut {
-    ($map_def:ident < $($g:ident),* >, $key:ty, $value:ty) => {
-        impl<$($g,)*> LookupMut for $map_def<$($g,)*> {
-            type Key = $key;
-            type Value = $value;
+    ($map_type:ident < $($gen:ident),* > ) => {
+        impl<$($gen,)*> LookupMut for $map_type<$($gen,)*> {
             unsafe fn lookup_mut<'a>(&'a self, key: &Self::Key) -> Option<&'a mut Self::Value> {
-                bpf_map_lookup_elem(&self.0, key)
+                bpf_map_lookup_elem(&self.def, key)
             }
         }
-    }
+    };
 }
 
-/// A map dedicated to redirecting packet processing to given CPUs, as
-/// part of an XDP BPF program.
-///
-/// Example :
-///
-/// ```
-/// use rebpf::maps::{CpuMap, Redirect};
-/// use rebpf::{XdpAction, XdpMd};
-/// use rebpf_macro::sec;
-///
-/// // Allocate a map to be able to dispatch traffic to the first 8 CPUs of the system.
-/// #[sec("maps")]
-/// pub static cpu_map: CpuMap = CpuMap::new(8);
-///
-/// #[sec("xdp_redirect_cpu")]
-/// pub fn redirect_cpu(ctx: &XdpMd) -> XdpAction {
-///     // Redirect all traffic to the CPU 2
-///     cpu_map.redirect(2)
-/// }
-/// ```
-#[repr(transparent)]
-pub struct CpuMap(BpfMapDef<u32, i32>);
+map_def! {
+    /// A map dedicated to redirecting packet processing to given CPUs, as
+    /// part of an XDP BPF program.
+    ///
+    /// Example :
+    ///
+    /// ```
+    /// use rebpf::maps::{CpuMap, Redirect};
+    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf_macro::sec;
+    ///
+    /// // Allocate a map to be able to dispatch traffic to the first 8 CPUs of the system.
+    /// #[sec("maps")]
+    /// pub static cpu_map: CpuMap = CpuMap::new(8);
+    ///
+    /// #[sec("xdp_redirect_cpu")]
+    /// pub fn redirect_cpu(ctx: &XdpMd) -> XdpAction {
+    ///     // Redirect all traffic to the CPU 2
+    ///     cpu_map.redirect(2)
+    /// }
+    /// ```
+    struct CpuMap: BpfMapType::CPUMAP
+}
 
-impl_map!(CpuMap<>, BpfMapType::CPUMAP);
-impl_map_redirect!(CpuMap<>);
+impl_map_redirect!(CpuMap);
 
-/// A map dedicated to redirecting packet processing to userspace AF_XDP sockets
-/// as part of an XDP BPF program.
-///
-/// Example :
-///
-/// ```
-/// use rebpf::maps::{XskMap, Redirect};
-/// use rebpf::{XdpAction, XdpMd};
-/// use rebpf_macro::sec;
-///
-/// // Allocate a single-slot map to host our only socket.
-/// // The userspace application must then feed it with the socket FD.
-/// #[sec("maps")]
-/// pub static xsk_map: XskMap = XskMap::new(1);
-///
-/// #[sec("xdp_redirect_xsk")]
-/// pub fn redirect_xsk(ctx: &XdpMd) -> XdpAction {
-///     // Redirect all traffic to the only open socket
-///     xsk_map.redirect(0)
-/// }
-/// ```
-#[repr(transparent)]
-pub struct XskMap(BpfMapDef<u32, i32>);
+map_def! {
+    /// A map dedicated to redirecting packet processing to userspace AF_XDP sockets
+    /// as part of an XDP BPF program.
+    ///
+    /// Example :
+    ///
+    /// ```
+    /// use rebpf::maps::{XskMap, Redirect};
+    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf_macro::sec;
+    ///
+    /// // Allocate a single-slot map to host our only socket.
+    /// // The userspace application must then feed it with the socket FD.
+    /// #[sec("maps")]
+    /// pub static xsk_map: XskMap = XskMap::new(1);
+    ///
+    /// #[sec("xdp_redirect_xsk")]
+    /// pub fn redirect_xsk(ctx: &XdpMd) -> XdpAction {
+    ///     // Redirect all traffic to the only open socket
+    ///     xsk_map.redirect(0)
+    /// }
+    /// ```
+    struct XskMap: BpfMapType::XSKMAP
+}
+impl_map_redirect!(XskMap);
 
-impl_map!(XskMap<>, BpfMapType::XSKMAP);
-impl_map_redirect!(XskMap<>);
+map_def! {
+    /// A map dedicated to redirecting packet processing to other network devices
+    /// as part of an XDP BPF program.
+    ///
+    /// Example :
+    ///
+    /// ```
+    /// use rebpf::maps::{DevMap, Redirect};
+    /// use rebpf::{XdpAction, XdpMd};
+    /// use rebpf_macro::sec;
+    ///
+    /// // Allocate a single-slot map to host our port map.
+    /// // The userspace application must take care of setting the interface index
+    /// // of the target to the slot 0 of the map.
+    /// #[sec("maps")]
+    /// pub static dev_map: DevMap = DevMap::new(1);
+    ///
+    /// #[sec("xdp_redirect_dev")]
+    /// pub fn redirect_dev(ctx: &XdpMd) -> XdpAction {
+    ///     // Redirect all traffic to the only open socket
+    ///     dev_map.redirect(0)
+    /// }
+    /// ```
+    struct DevMap: BpfMapType::DEVMAP
+}
+impl_map_redirect!(DevMap);
 
-/// A map dedicated to redirecting packet processing to other network devices
-/// as part of an XDP BPF program.
-///
-/// Example :
-///
-/// ```
-/// use rebpf::maps::{DevMap, Redirect};
-/// use rebpf::{XdpAction, XdpMd};
-/// use rebpf_macro::sec;
-///
-/// // Allocate a single-slot map to host our port map.
-/// // The userspace application must take care of setting the interface index
-/// // of the target to the slot 0 of the map.
-/// #[sec("maps")]
-/// pub static dev_map: DevMap = DevMap::new(1);
-///
-/// #[sec("xdp_redirect_dev")]
-/// pub fn redirect_dev(ctx: &XdpMd) -> XdpAction {
-///     // Redirect all traffic to the only open socket
-///     dev_map.redirect(0)
-/// }
-/// ```
-#[repr(transparent)]
-pub struct DevMap(BpfMapDef<u32, i32>);
+map_def! {
+    /// A map behaving as a simple contiguous array, with arbitrary data as content.
+    struct Array<T>: BpfMapType::ARRAY
+}
+impl_map_lookup_mut!(Array<T>);
 
-impl_map!(DevMap<>, BpfMapType::DEVMAP);
-impl_map_redirect!(DevMap<>);
+map_def! {
+    /// This map represent a faster array maintained on a per-CPU basis.
+    struct PerCpuArray<T>: BpfMapType::PERCPU_ARRAY
+}
 
-/// A map dedicated to redirecting packet processing to other network devices
-/// as part of an XDP BPF program.
-///
-/// Example :
-///
-/// ```
-/// use rebpf::maps::{Array, Lookup};
-/// use rebpf::{XdpAction, XdpMd};
-/// use rebpf_macro::sec;
-///
-/// // Allocate a single-slot map to host our port map.
-/// // The userspace application must take care of setting the interface index
-/// // of the target to the slot 0 of the map.
-/// #[sec("maps")]
-/// pub static array: Array<u32> = Array::new(1);
-///
-/// #[sec("xdp_potential_drop")]
-/// pub fn redirect_dev(ctx: &XdpMd) -> XdpAction {
-///     // Redirect all traffic to the only open socket
-///     let key = 0;
-///     match unsafe { array.lookup_mut(&key) } {
-///         Some(0) => XdpAction::DROP,
-///         Some(_) => XdpAction::PASS,
-///         None => XdpAction::ABORTED,
-///     }
-/// }
-/// ```
-#[repr(transparent)]
-pub struct Array<T>(BpfMapDef<u32, T>);
-
-impl_map!(Array<T>, BpfMapType::ARRAY);
-impl_map_lookup_mut!(Array<T>, u32, T);
-
-/// This map represent a faster array maintained on a per-CPU basis.
-#[repr(transparent)]
-pub struct PerCpuArray<T>(BpfMapDef<u32, T>);
-
-impl_map!(PerCpuArray<T>, BpfMapType::PERCPU_ARRAY);
-impl_map_lookup_mut!(PerCpuArray<T>, u32, T);
+impl_map_lookup_mut!(PerCpuArray<T>);

--- a/rebpf/src/bpf/maps.rs
+++ b/rebpf/src/bpf/maps.rs
@@ -1,4 +1,5 @@
 use crate::{
+    error::Result,
     helpers::{bpf_map_lookup_elem, bpf_redirect_map},
     libbpf::{BpfMapDef, BpfMapType, XdpAction},
     maps::*,

--- a/rebpf/src/error.rs
+++ b/rebpf/src/error.rs
@@ -1,5 +1,7 @@
+pub type Result<T> = std::result::Result<T, Error>;
+
 #[derive(Debug)]
-pub enum Error {    
+pub enum Error {
     Libbpf(String, LibbpfError),
     Generic(GenericError),
     InvalidProgName,
@@ -12,7 +14,7 @@ pub enum GenericError {
     CStringConversion(std::ffi::NulError),
     CCharConversion(std::str::Utf8Error),
     InvalidPath,
-    InvalidInterfaceName(String)
+    InvalidInterfaceName(String),
 }
 
 #[derive(Debug)]

--- a/rebpf/src/lib.rs
+++ b/rebpf/src/lib.rs
@@ -10,7 +10,7 @@ pub mod helpers;
 pub mod interface;
 pub mod libbpf;
 pub mod maps;
-//pub mod userspace;
+pub mod userspace;
 
 pub const LICENSE: [u8; 4] = ['G' as u8, 'P' as u8, 'L' as u8, '\0' as u8]; //b"GPL\0"
 pub const VERSION: u32 = 0xFFFFFFFE;

--- a/rebpf/src/lib.rs
+++ b/rebpf/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod helpers;
 pub mod interface;
 pub mod libbpf;
+pub mod maps;
 //pub mod userspace;
 
 pub const LICENSE: [u8; 4] = ['G' as u8, 'P' as u8, 'L' as u8, '\0' as u8]; //b"GPL\0"

--- a/rebpf/src/lib.rs
+++ b/rebpf/src/lib.rs
@@ -4,11 +4,11 @@ mod utils;
 extern crate function_name;
 
 pub use rebpf_macro;
+pub mod bpf;
 pub mod error;
+pub mod helpers;
 pub mod interface;
 pub mod libbpf;
-pub mod helpers;
-pub mod bpf;
 //pub mod userspace;
 
 pub const LICENSE: [u8; 4] = ['G' as u8, 'P' as u8, 'L' as u8, '\0' as u8]; //b"GPL\0"

--- a/rebpf/src/libbpf.rs
+++ b/rebpf/src/libbpf.rs
@@ -356,17 +356,14 @@ pub fn bpf_object__find_program_by_title(
 }
 
 #[allow(non_snake_case)]
-pub fn bpf_object__find_map_by_name(
-    bpf_object: &BpfObject,
-    name: &str,
-) -> Result<Option<BpfMap>, Error> {
+pub fn bpf_object__find_map_by_name(bpf_object: &BpfObject, name: &str) -> Result<BpfMap, Error> {
     let name_cs = str_to_cstring(name)?;
     let bpf_map =
         unsafe { libbpf_sys::bpf_object__find_map_by_name(bpf_object.pobj, name_cs.as_ptr()) };
     if bpf_map.is_null() {
-        return Ok(None);
+        return Err(Error::InvalidMapName);
     }
-    Ok(Some(BpfMap { pmap: bpf_map }))
+    Ok(BpfMap { pmap: bpf_map })
 }
 
 #[allow(non_snake_case)]

--- a/rebpf/src/libbpf.rs
+++ b/rebpf/src/libbpf.rs
@@ -1,5 +1,5 @@
 use crate::{
-    error::{Error, LibbpfError},
+    error::{Error, LibbpfError, Result},
     interface,
     utils::*,
 };
@@ -169,7 +169,7 @@ impl BpfProgInfo {
     }
 
     #[named]
-    pub fn name(&self) -> Result<String, Error> {
+    pub fn name(&self) -> Result<String> {
         let name = &self.info.name;
         c_char_pointer_to_string(name.as_ptr())
     }
@@ -256,14 +256,14 @@ impl BpfMapInfo {
         map_type
     }
 
-    pub fn name(&self) -> Result<String, Error> {
+    pub fn name(&self) -> Result<String> {
         let name = &self.info.name;
         c_char_pointer_to_string(name.as_ptr())
     }
 }
 
 #[named]
-pub fn bpf_obj_get_info_by_fd<T: BpfFd>(bpf_fd: &T) -> Result<T::BpfInfoType, Error>
+pub fn bpf_obj_get_info_by_fd<T: BpfFd>(bpf_fd: &T) -> Result<T::BpfInfoType>
 where
     T::BpfInfoType: BpfInfo,
 {
@@ -284,7 +284,7 @@ where
 pub fn bpf_prog_load(
     file_path: &Path,
     bpf_prog_type: BpfProgType,
-) -> Result<(BpfObject, BpfProgFd), Error> {
+) -> Result<(BpfObject, BpfProgFd)> {
     let mut pobj: *mut libbpf_sys::bpf_object = ptr::null_mut();
     let mut prog_fd: raw::c_int = -1;
 
@@ -326,7 +326,7 @@ pub fn bpf_map_update_elem<T, U>(
     key: &T,
     value: &U,
     flags: BpfUpdateElemFlags,
-) -> Result<(), Error> {
+) -> Result<()> {
     let key = to_const_c_void(key);
     let value = to_const_c_void(value);
     match unsafe { libbpf_sys::bpf_map_update_elem(map_fd.fd(), key, value, flags.bits() as u64) } {
@@ -342,7 +342,7 @@ pub fn bpf_map_update_elem<T, U>(
 pub fn bpf_object__find_program_by_title(
     bpf_object: &BpfObject,
     title: &str,
-) -> Result<Option<BpfProgram>, Error> {
+) -> Result<Option<BpfProgram>> {
     let title_cs: CString = str_to_cstring(title)?;
     let bpf_program: *mut libbpf_sys::bpf_program = unsafe {
         libbpf_sys::bpf_object__find_program_by_title(bpf_object.pobj, title_cs.as_ptr())
@@ -356,7 +356,7 @@ pub fn bpf_object__find_program_by_title(
 }
 
 #[allow(non_snake_case)]
-pub fn bpf_object__find_map_by_name(bpf_object: &BpfObject, name: &str) -> Result<BpfMap, Error> {
+pub fn bpf_object__find_map_by_name(bpf_object: &BpfObject, name: &str) -> Result<BpfMap> {
     let name_cs = str_to_cstring(name)?;
     let bpf_map =
         unsafe { libbpf_sys::bpf_object__find_map_by_name(bpf_object.pobj, name_cs.as_ptr()) };
@@ -399,7 +399,7 @@ pub fn bpf_program__next(
 
 #[allow(non_snake_case)]
 #[named]
-pub fn bpf_program__fd(bpf_program: &BpfProgram) -> Result<BpfProgFd, Error> {
+pub fn bpf_program__fd(bpf_program: &BpfProgram) -> Result<BpfProgFd> {
     let prog_fd = unsafe { libbpf_sys::bpf_program__fd(bpf_program.pprogram) };
     if prog_fd < 0 {
         return map_libbpf_error(function_name!(), LibbpfError::InvalidFd);
@@ -412,7 +412,7 @@ pub fn bpf_program__fd(bpf_program: &BpfProgram) -> Result<BpfProgFd, Error> {
 
 #[allow(non_snake_case)]
 #[named]
-pub fn bpf_program__title(bpf_program: &BpfProgram) -> Result<String, Error> {
+pub fn bpf_program__title(bpf_program: &BpfProgram) -> Result<String> {
     let title_c_char_p = unsafe { libbpf_sys::bpf_program__title(bpf_program.pprogram, false) };
     if title_c_char_p.is_null() {
         return map_libbpf_error(function_name!(), LibbpfError::InvalidTitle);
@@ -422,7 +422,7 @@ pub fn bpf_program__title(bpf_program: &BpfProgram) -> Result<String, Error> {
 
 #[allow(non_snake_case)]
 #[named]
-pub fn bpf_map__fd<T, U>(bpf_map: &BpfMap) -> Result<BpfMapFd<T, U>, Error> {
+pub fn bpf_map__fd<T, U>(bpf_map: &BpfMap) -> Result<BpfMapFd<T, U>> {
     let fd = unsafe { libbpf_sys::bpf_map__fd(bpf_map.pmap) };
     if fd < 0 {
         return map_libbpf_error(function_name!(), LibbpfError::InvalidFd);
@@ -487,7 +487,7 @@ pub fn bpf_set_link_xdp_fd(
     interface: &interface::Interface,
     bpf_fd: Option<&BpfProgFd>,
     xdp_flags: XdpFlags,
-) -> Result<(), Error> {
+) -> Result<()> {
     let err = unsafe {
         if bpf_fd.is_some() {
             let bpf_fd = bpf_fd.unwrap();

--- a/rebpf/src/libbpf.rs
+++ b/rebpf/src/libbpf.rs
@@ -260,6 +260,13 @@ impl BpfMapInfo {
         let name = &self.info.name;
         c_char_pointer_to_string(name.as_ptr())
     }
+
+    pub fn matches_map_def<K, V>(&self, map_def: &BpfMapDef<K, V>) -> bool {
+        let other = map_def.to_bpf_map_info();
+        return self.value_size() == other.value_size()
+            && self.key_size() == other.key_size()
+            && self.type_() == other.type_();
+    }
 }
 
 #[named]

--- a/rebpf/src/libbpf.rs
+++ b/rebpf/src/libbpf.rs
@@ -45,7 +45,7 @@ bitflags::bitflags! {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum BpfMapType {

--- a/rebpf/src/maps.rs
+++ b/rebpf/src/maps.rs
@@ -1,3 +1,6 @@
+use crate::error::Result;
+use crate::libbpf::BpfUpdateElemFlags;
+
 /// This crate contains traits defining common operations on BPF maps that can
 /// be executed both on the userspace side and the BPF side.
 
@@ -14,4 +17,16 @@ pub trait Lookup: Map {
     ///
     /// Note that the return value is a mere copy of said content.
     fn lookup(&self, key: &Self::Key) -> Option<Self::Value>;
+}
+
+pub trait Update: Map {
+    /// Update a value inside the map.
+    ///
+    /// This operation is considered as atomic.
+    fn update<'a>(
+        &'a mut self,
+        key: &Self::Key,
+        value: &Self::Value,
+        flags: BpfUpdateElemFlags,
+    ) -> Result<()>;
 }

--- a/rebpf/src/maps.rs
+++ b/rebpf/src/maps.rs
@@ -1,9 +1,15 @@
 /// This crate contains traits defining common operations on BPF maps that can
 /// be executed both on the userspace side and the BPF side.
 
-pub trait Lookup {
+/// This trait is implemented by all the map wrapper types, as
+/// as convenient way to communicate their underlying types to the
+/// Rust type system.
+pub trait Map {
     type Key;
     type Value;
+}
+
+pub trait Lookup: Map {
     /// Lookup the map content associated with the given key.
     ///
     /// Note that the return value is a mere copy of said content.

--- a/rebpf/src/maps.rs
+++ b/rebpf/src/maps.rs
@@ -1,0 +1,11 @@
+/// This crate contains traits defining common operations on BPF maps that can
+/// be executed both on the userspace side and the BPF side.
+
+pub trait Lookup {
+    type Key;
+    type Value;
+    /// Lookup the map content associated with the given key.
+    ///
+    /// Note that the return value is a mere copy of said content.
+    fn lookup(&self, key: &Self::Key) -> Option<Self::Value>;
+}

--- a/rebpf/src/userspace/maps.rs
+++ b/rebpf/src/userspace/maps.rs
@@ -1,0 +1,112 @@
+use crate::error::{Error, Result};
+use crate::libbpf;
+use crate::libbpf::{BpfMapDef, BpfMapFd, BpfMapInfo, BpfMapType, BpfObject, BpfUpdateElemFlags};
+use crate::maps::*;
+
+macro_rules! map_impl {
+    ($type_const:expr) => {
+        pub fn from_obj(bpf_obj: &BpfObject, map_name: &str) -> Result<Self> {
+            let fd = extract_map_fd(bpf_obj, map_name)?;
+            Ok(Self { fd })
+        }
+        pub fn extract_info(&self) -> Result<BpfMapInfo> {
+            extract_checked_info(&self.fd, $type_const)
+        }
+    };
+}
+
+fn extract_map_fd<K, V>(bpf_obj: &BpfObject, map_name: &str) -> Result<BpfMapFd<K, V>> {
+    let bpf_map = libbpf::bpf_object__find_map_by_name(bpf_obj, map_name)?;
+    libbpf::bpf_map__fd(&bpf_map)
+}
+
+fn extract_checked_info<K, V>(map_fd: &BpfMapFd<K, V>, map_type: BpfMapType) -> Result<BpfMapInfo> {
+    let info = libbpf::bpf_obj_get_info_by_fd(map_fd)?;
+    if info.matches_map_def::<K, V>(&BpfMapDef::new(map_type, 0)) {
+        Ok(info)
+    } else {
+        Err(Error::Custom(
+            "The wrapper type doesn't match the map object".to_owned(),
+        ))
+    }
+}
+
+macro_rules! map_def {
+    ($(#[$outer:meta])*
+    struct $map_type:ident < $key:ty, $value:ty >: $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type<$key, $value> {
+            fd: BpfMapFd<$key, $value>,
+        }
+        impl<$key, $value> $map_type<$key, $value> { map_new! {$map_type<$key, $value>: $type_const} }
+        impl<$key, $value> Map for $map_type<$key, $value> { type Key = $key; type Value = $value; }
+    };
+    ($(#[$outer:meta])*
+    struct $map_type:ident < $value:ident >: $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type <$value> {
+            fd: BpfMapFd<u32, $value>,
+        }
+        impl<$value> $map_type<$value> { map_impl!($type_const); }
+        impl<$value> Map for $map_type<$value> { type Key = u32; type Value = $value; }
+    };
+    ($(#[$outer:meta])*
+    struct $map_type:ident : $type_const:expr) => {
+        #[repr(transparent)]
+        $(#[$outer])*
+        pub struct $map_type {
+            fd: BpfMapFd<u32, u32>,
+        }
+        impl $map_type { map_impl!($type_const); }
+        impl Map for $map_type { type Key = u32; type Value = u32; }
+    };
+}
+
+macro_rules! impl_update {
+    ($map_type:ident < $($gen:ident),* > ) => {
+        impl<$($gen,)*> Update for $map_type<$($gen,)*> { impl_update_gen!(); }
+    };
+    ($map_type:ident) => {
+        impl Update for $map_type { impl_update_gen!(); }
+    };
+}
+
+macro_rules! impl_update_gen {
+    () => {
+        fn update(&mut self, key: &Self::Key, value: &Self::Value, flags: BpfUpdateElemFlags) -> Result<()> {
+            libbpf::bpf_map_update_elem(&self.fd, key, value, flags)
+        }
+    };
+}
+
+macro_rules! impl_lookup {
+    ($map_type:ident < $value:ident > ) => {
+        impl<$value: Default> Lookup for $map_type<$value> {
+            impl_lookup_gen!();
+        }
+    };
+    ($map_type:ident) => {
+        impl Lookup for $map_type {
+            impl_lookup_gen!();
+        }
+    };
+}
+
+macro_rules! impl_lookup_gen {
+    () => {
+        fn lookup(&self, key: &Self::Key) -> Option<Self::Value> {
+            let mut value: Self::Value = Default::default();
+            libbpf::bpf_map_lookup_elem(&self.fd, key, &mut value).map(move |_| value)
+        }
+    };
+}
+
+map_def!(struct CpuMap: BpfMapType::CPUMAP);
+impl_update!(CpuMap);
+impl_lookup!(CpuMap);
+
+map_def!(struct Array<T>: BpfMapType::ARRAY);
+impl_update!(Array<T>);
+impl_lookup!(Array<T>);

--- a/rebpf/src/userspace/mod.rs
+++ b/rebpf/src/userspace/mod.rs
@@ -1,0 +1,2 @@
+pub mod maps;
+


### PR DESCRIPTION
Sorry, this is a bit of a monster PR.

Apart from changing the Lookup trait to a LookupMut (to be able to add a non-mut variant), there's a tiny API break, as I changed the Result<Option<..>> into a simple Result<..> as the None variant matches the Error::InvalidMapName anyways.

I also introduced a Result<T> type alias in an effort to get the type names under control.

Oh, and we can now update maps in a safe way :)